### PR TITLE
fix: remove TextArea resize

### DIFF
--- a/src/components/Forms/Input.js
+++ b/src/components/Forms/Input.js
@@ -19,6 +19,7 @@ const StyledTextArea = styled.textarea`
     height: 100px;
     font-size: 0.7em;
     font-family: 'Rubik', sans-serif;
+    resize: none;
 
     :focus {
         outline: none;


### PR DESCRIPTION
fixed bug where user can resize text area to odd effect. 

see screenshot 
<img width="760" alt="Screen Shot 2021-07-06 at 7 02 42 PM" src="https://user-images.githubusercontent.com/57849986/124676597-d8432980-de8c-11eb-9354-f2df930f316f.png">
